### PR TITLE
CI: resolve the pdf artifact update error

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -35,13 +35,6 @@ jobs:
       - name: make pdf
         run: |
           make all
-        
-      - name: "Upload PDF artifact"
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-pdf
-          path: _build/*.pdf
-          retention-days: 7
 
       - name: make html
         run: |
@@ -52,6 +45,15 @@ jobs:
         with:
           name: documentation-html
           path: doc/_build/html
+          retention-days: 7
+
+      - name: "Upload PDF artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: cheatsheet-pdf
+          path: |
+            _build/*.pdf
+            _build/*.png
           retention-days: 7
 
       - name: Prepare files for gh-pages deployment

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -35,6 +35,13 @@ jobs:
       - name: make pdf
         run: |
           make all
+        
+      - name: "Upload PDF artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation-pdf
+          path: _build/{*.pdf,*.png}
+          retention-days: 7
 
       - name: make html
         run: |
@@ -45,13 +52,6 @@ jobs:
         with:
           name: documentation-html
           path: doc/_build/html
-          retention-days: 7
-
-      - name: "Upload PDF artifact"
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-pdf
-          path: _build/{*.pdf,*.png}
           retention-days: 7
 
       - name: Prepare files for gh-pages deployment

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: documentation-pdf
-          path: _build/{*.pdf,*.png}
+          path: _build/*.pdf
           retention-days: 7
 
       - name: make html

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -51,9 +51,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cheatsheet-pdf
-          path: |
-            _build/*.pdf
-            _build/*.png
+          path: _build/*.pdf
           retention-days: 7
 
       - name: Prepare files for gh-pages deployment


### PR DESCRIPTION
Fix the encountering indicates that no files were found at the specified path (_build/{*.pdf,*.png}) during the artifact upload step.
Fix https://github.com/ansys/pyansys-cheat-sheet/pull/41#issuecomment-1600510089 issue mentioned here 