### PR TITLE
Edits to PyMotorCAD cheat sheets

### DIFF
--- a/cheat_sheets/pymotorcad_cheat_sheet/pymotorcad_cheat_sheet.tex
+++ b/cheat_sheets/pymotorcad_cheat_sheet/pymotorcad_cheat_sheet.tex
@@ -1,21 +1,21 @@
 \documentclass[landscape]{article}
 \usepackage{{./../static/style}}
 \pdfinfo{
-  /Title (PyMotorcad cheat sheet)
+  /Title (PyMotorCAD cheat sheet)
   /Creator (TeX)
   /Producer (pdfTeX 1.40.0)
   /Author (Ansys)
   /Subject (PyMotorCAD)
-  /Keywords (PyAnsys, PyMotorCAD, MotorCAD, cheat sheet)}
+  /Keywords (PyAnsys, PyMotorCAD, Motor-CAD, cheat sheet, template)}
 
 \begin{document}
 \raggedright
 \footnotesize
 \begin{center}
-     \Huge{\textbf{PyMotorCAD-API Cheatsheet}} 
+     \Huge{\textbf{PyMotorCAD-API cheat sheet}} 
 \end{center}
 \begin{center}
-	\small{\textbf{based on version:0.1 (stable)}} 
+	\small{\textbf{Version: 0.1 (stable)}} 
 \end{center}
 \AddToShipoutPicture*
   {\put(670,577.5){\includegraphics[height = 1.2cm]{ansys.png}}}
@@ -32,73 +32,73 @@
 % session starts here. 
 % First colomn
 % --------------------------------------------------------------------------------
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Launching MotorCAD using PyMotorCAD}
-To launch Motor-CAD instance locally and exit:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Launch Motor-CAD using PyMotorCAD}
+Launch a Motor-CAD instance locally and then exit:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_0.py}
 
 
-%\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Loading Template}
-%To load template and save file:
+%\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Load template}
+%Load template and save file:
 %\begin{lstlisting}[language=Python]
 %mcad.load_template(template_name)
 %mcad.save_to_file(os.path.join(working_folder, mcad_name + ".mot"))
 %\end{lstlisting}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Geometrical properties}
-To specify the motor geometry:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Geometry properties}
+Specify the motor geometry:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_1.py}
 
-To set winding patterns:
+Set winding patterns:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_2.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Material Assignment}
-To set stater and rotor lamination materials:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Material assignment}
+Set stater and rotor lamination materials:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_3.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Building Model}
-To set building commands:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Model motor}
+Set building commands:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_4.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} E-magnetic Performance Curves in LAB}
-To set lab operating mode:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} E-magnetic performance curves in LAB}
+Set lab operating mode:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_5.py}
 
-To calculate the E-Magnetic performance:
+Calculate the E-Magnetic performance:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_6.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Operating Point Calculation}
-To set the operating point variables:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Operating point calculation}
+Set the operating point variables:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_7.py}
 
-To calculate operating point:
+Calculate the operating point:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_8.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Electromagnetic Calculations in Emag}
-To perform electromagnetic calculations:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Electromagnetic calculations in Emag}
+Perform electromagnetic calculations:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_9.py}
 
 \section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Results}
 \pythoncode{scripts/generated_scripts/pymotorcad_script_10.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} PyMotorCAD Scripting in MATLAB}
-The Python version that MATLAB is using has the \textit{ansys.motorcad.core} package installed, PyMotorCAD is available to use in MATLAB.
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} PyMotorCAD scripting in MATLAB}
+The Python version that MATLAB is using has the \textit{ansys.motorcad.core} package installed. PyMotorCAD is available to use in MATLAB.
 
-To import the \textit{ansys.motorcad.core} python package for use in MATLAB:
+Import the \textit{ansys.motorcad.core} Python package for use in MATLAB:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_11.py}
 
-\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Backwards Compatibility}
-To use ActiveX scripts to connect to Motor-CAD:
+\section{\includegraphics[height=\fontcharht\font`\S]{slash.png} Backwards compatibility}
+Use ActiveX scripts to connect to Motor-CAD:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_12.py}
 
-To use PyMotorCAD to connect to Motor-CAD:
+Use PyMotorCAD to connect to Motor-CAD:
 \pythoncode{scripts/generated_scripts/pymotorcad_script_13.py}
 
-\subsection{References from PyMotorCad Documentation}
+\subsection{References from PyMotorCAD documentation}
 \begin{center}
 \begin{itemize}
-\item \href{https://motorcad.docs.pyansys.com/version/stable/getting_started/index.html}{\color{blue}{Getting Started}}
+\item \href{https://motorcad.docs.pyansys.com/version/stable/getting_started/index.html}{\color{blue}{Getting started}}
 \item \href{https://motorcad.docs.pyansys.com/version/stable/examples/index.html}{\color{blue}{Examples}}
-\item \href{https://motorcad.docs.pyansys.com/version/stable/methods/index.html}{\color{blue}{API Reference}}
+\item \href{https://motorcad.docs.pyansys.com/version/stable/methods/index.html}{\color{blue}{API reference}}
 \end{itemize}
 \end{center}
 \end{multicols}

--- a/cheat_sheets/pymotorcad_cheat_sheet/pymotorcad_script.py
+++ b/cheat_sheets/pymotorcad_cheat_sheet/pymotorcad_script.py
@@ -2,13 +2,13 @@ import ansys.motorcad.core as pymotorcad
 
 mcad = pymotorcad.MotorCAD()
 mcad.load_from_file(r"path/motor_cad.mot")
-# loading pre-defined template
+# Load predefined template
 mcad.load_template(template_name)
 # saving file to working_folder
 mcad.save_to_file(
     os.path.join(working_folder, mcad_name + ".mot")
 )
-# existing MotorCAD
+# Exit Motor-CAD
 mcad.quit()
 # BREAK BLOCK
 
@@ -34,7 +34,7 @@ mcad.set_variable("ModelBuildSpeed_MotorLAB", 10000)
 mcad.set_variable("MaxModelCurrent_MotorLAB", 480)
 mcad.set_variable("BuildSatModel_MotorLAB", True)
 
-# Setting lab context and building model
+# Set lab context and build model
 mcad.set_motorlab_context()
 mcad.clear_model_build_lab()
 mcad.build_model_lab()
@@ -62,28 +62,28 @@ mcad.set_variable("LabMagneticCoupling", 0)
 mcad.calculate_operating_point_lab()
 # BREAK BLOCK
 
-# Set the torque calculation options.
+# Set the torque calculation options
 points_per_cycle = 60
 number_cycles = 1
 mcad.set_variable("TorquePointsPerCycle", points_per_cycle)
 mcad.set_variable("TorqueNumberCycles", number_cycles)
-# Disable all performance tests except the ones for transient torque.
+# Disable all performance tests except the ones for transient torque
 mcad.set_variable("BackEMFCalculation", False)
 mcad.set_variable("CoggingTorqueCalculation", False)
-# Enable transient torque.
+# Enable transient torque
 mcad.set_variable("TorqueCalculation", True)
-# For running  Emag performance tests
+# Run Emag performance tests
 mcad.do_magnetic_calculation()
 # BREAK BLOCK
 
-# Getting the transient torque waveform in Emag
+# Get the transient torque waveform in Emag
 for n in range(points_per_cycle):
     (x, y) = mcad.get_magnetic_graph_point("TorqueVW", n)
     rotor_position.append(x)
     torque_.append(y)
-# line voltage calculation
+# Calculate line voltage
 line_voltage = mcad.get_variable("PeakLineLineVoltage")
-# Retrieving lab performance curves
+# Retrieve lab performance curves
 data = io.loadmat(
     os.path.join(
         working_folder, mcad_name, "Lab", "MotorLAB_elecdata.mat"


### PR DESCRIPTION
@Revathyvenugopal162 and @pvinod13 Here are my edits to the PyMotorCAD cheat sheet files. I do know that you changed ``\texttt`` to ``\textt`` when you did your alignment stuff. I do want to point out that the PyAEDT cheat sheets use ``\texttt`` and seem to be fine. This repo uses ``\textit`` I assume the ``i`` is for italics, which we don't want. If I'm correct, what should I change the tag to? One of these: ``\texttt`` to ``\textt``?

I'll add the boiler plate content for "Documentation and issues" in the README file and overall index.rst file for PyMotor doc now in https://github.com/ansys/pymotorcad/pull/163.